### PR TITLE
fix: externalize vue

### DIFF
--- a/build/rollup.config.base.mjs
+++ b/build/rollup.config.base.mjs
@@ -4,10 +4,11 @@ import cjs from '@rollup/plugin-commonjs'
 import replace from '@rollup/plugin-replace'
 import typescript from 'rollup-plugin-typescript2';
 import terser from '@rollup/plugin-terser';
-import config from '../package.json' assert { type: "json" };
+import config from '../package.json' with { type: "json" };
 
 export default {
 	input: 'src/index.ts',
+	external: ['vue'],
 	plugins: [
 		resolve({
 			mainFields: ['module', 'main'],

--- a/build/rollup.config.browser.mjs
+++ b/build/rollup.config.browser.mjs
@@ -7,6 +7,7 @@ const config = Object.assign({}, base, {
 		name: 'VueObserveVisibility',
 		file: 'dist/vue-observe-visibility.min.js',
 		format: 'iife',
+		globals: { vue: 'Vue' },
 	},
 })
 

--- a/build/rollup.config.umd.mjs
+++ b/build/rollup.config.umd.mjs
@@ -6,6 +6,7 @@ const config = Object.assign({}, base, {
 		name: 'vue-observe-visibility',
 		file: 'dist/vue-observe-visibility.umd.js',
 		format: 'umd',
+		globals: { vue: 'Vue' },
 	},
 })
 


### PR DESCRIPTION
### Description

The current bundles are problematic because `vue` is not properly externalized. As this plugin defined `vue` as a `peerDependency` it basically states that consumers are responsible for installing version ranges that match. Because of the current configuration `vue` is partly installed and also exposes `__VUE_HMR_RUNTIME__` among others which conflicts with different `vue` instances and creates issues.

This change will externalize `vue` and fix issues in this regards.